### PR TITLE
Zookeeper Local Bugfix

### DIFF
--- a/v1/fleet-local/control/chronos@.service
+++ b/v1/fleet-local/control/chronos@.service
@@ -38,7 +38,7 @@ ExecStart=/usr/bin/sh -c "docker run \
   --http_port 4400 \
   --mesos_authentication_principal $($MESOS_USERNAME) \
   --mesos_authentication_secret_file /opt/mesos/framework-secret \
-  --master zk://$($ZK_USERNAME):$($ZK_PASSWORD)@${ZOOKEEPER_HOST}/mesos \
+  --master zk://$($ZK_USERNAME):$($ZK_PASSWORD)@$ZOOKEEPER_HOST/mesos \
   --mesos_framework_name chronos-$(hostname) \
   --zk_hosts ${ZOOKEEPER_HOST}"
 

--- a/v1/fleet-local/control/chronos@.service
+++ b/v1/fleet-local/control/chronos@.service
@@ -10,7 +10,6 @@ Environment=ZOOKEEPER_HOST=localhost:2181
 Environment="IMAGE=etcdctl get /images/chronos"
 Environment="ZK_USERNAME=etcdctl get /zookeeper/config/username"
 Environment="ZK_PASSWORD=etcdctl get /zookeeper/config/password"
-Environment="ZK_ENDPOINT=etcdctl get /zookeeper/config/endpoint"
 Environment="MESOS_USERNAME=etcdctl get /mesos/config/username"
 
 User=core
@@ -39,7 +38,7 @@ ExecStart=/usr/bin/sh -c "docker run \
   --http_port 4400 \
   --mesos_authentication_principal $($MESOS_USERNAME) \
   --mesos_authentication_secret_file /opt/mesos/framework-secret \
-  --master zk://$($ZK_USERNAME):$($ZK_PASSWORD)@$($ZK_ENDPOINT)/mesos \
+  --master zk://$($ZK_USERNAME):$($ZK_PASSWORD)@${ZOOKEEPER_HOST}/mesos \
   --mesos_framework_name chronos-$(hostname) \
   --zk_hosts ${ZOOKEEPER_HOST}"
 

--- a/v1/fleet-local/control/marathon@.service
+++ b/v1/fleet-local/control/marathon@.service
@@ -33,8 +33,8 @@ ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
   $($IMAGE) \
   --mesos_authentication_principal $($MESOS_USERNAME) \
   --mesos_authentication_secret_file /opt/mesos/framework-secret \
-  --master zk://$($ZK_USERNAME):$($ZK_PASSWORD)@${ZOOKEEPER_HOST}/mesos \
-  --zk zk://$($ZK_USERNAME):$($ZK_PASSWORD)@${ZOOKEEPER_HOST}/marathon \
+  --master zk://$($ZK_USERNAME):$($ZK_PASSWORD)@$ZOOKEEPER_HOST/mesos \
+  --zk zk://$($ZK_USERNAME):$($ZK_PASSWORD)@$ZOOKEEPER_HOST/marathon \
   --http_credentials $($USER):$($PASSWORD) \
   --checkpoint \
   --task_launch_timeout 300000"

--- a/v1/fleet-local/control/marathon@.service
+++ b/v1/fleet-local/control/marathon@.service
@@ -4,14 +4,13 @@ Requires=docker.service
 After=docker.service bootstrap.service zk-health.service mesos-master@%i.service
 
 [Service]
-Environment=ZOOKEEPER=localhost:2181
+Environment=ZOOKEEPER_HOST=localhost:2181
 Environment="IMAGE=etcdctl get /images/marathon"
 Environment="USER=etcdctl get /marathon/config/username"
 Environment="PASSWORD=etcdctl get /marathon/config/password"
 Environment="MESOS_USERNAME=etcdctl get /mesos/config/username"
 Environment="ZK_USERNAME=etcdctl get /zookeeper/config/username"
 Environment="ZK_PASSWORD=etcdctl get /zookeeper/config/password"
-Environment="ZK_ENDPOINT=etcdctl get /zookeeper/config/endpoint"
 
 User=core
 Restart=always
@@ -34,8 +33,8 @@ ExecStart=/usr/bin/sh -c "/usr/bin/docker run \
   $($IMAGE) \
   --mesos_authentication_principal $($MESOS_USERNAME) \
   --mesos_authentication_secret_file /opt/mesos/framework-secret \
-  --master zk://$($ZK_USERNAME):$($ZK_PASSWORD)@$($ZK_ENDPOINT)/mesos \
-  --zk zk://$($ZK_USERNAME):$($ZK_PASSWORD)@$($ZK_ENDPOINT)/marathon \
+  --master zk://$($ZK_USERNAME):$($ZK_PASSWORD)@${ZOOKEEPER_HOST}/mesos \
+  --zk zk://$($ZK_USERNAME):$($ZK_PASSWORD)@${ZOOKEEPER_HOST}/marathon \
   --http_credentials $($USER):$($PASSWORD) \
   --checkpoint \
   --task_launch_timeout 300000"

--- a/v1/setup/leader/001-defaults.sh
+++ b/v1/setup/leader/001-defaults.sh
@@ -15,40 +15,40 @@ echo "-------Leader node, beginning writing all default values to etcd-------"
 
 etcd-set /bootstrap.service/images-base-bootstrapped true
 
-etcd-set /images/gocron-logrotate     	"index.docker.io/behance/docker-gocron-logrotate"
-etcd-set /images/sumologic     			"index.docker.io/behance/docker-sumologic:latest"
-etcd-set /images/sumologic-syslog     	"index.docker.io/behance/docker-sumologic:syslog-latest"
-etcd-set /images/dd-agent     			"index.docker.io/behance/docker-dd-agent:latest"
-etcd-set /images/secrets-downloader		"index.docker.io/behance/docker-aws-secrets-downloader:latest"
-etcd-set /images/ecr-login				"index.docker.io/behance/ecr-login:latest"
-etcd-set /images/splunk					"index.docker.io/adobeplatform/docker-splunk:latest"
+etcd-set /images/gocron-logrotate       "index.docker.io/behance/docker-gocron-logrotate"
+etcd-set /images/sumologic              "index.docker.io/behance/docker-sumologic:latest"
+etcd-set /images/sumologic-syslog       "index.docker.io/behance/docker-sumologic:syslog-latest"
+etcd-set /images/dd-agent               "index.docker.io/behance/docker-dd-agent:latest"
+etcd-set /images/secrets-downloader     "index.docker.io/behance/docker-aws-secrets-downloader:latest"
+etcd-set /images/ecr-login              "index.docker.io/behance/ecr-login:latest"
+etcd-set /images/splunk                 "index.docker.io/adobeplatform/docker-splunk:latest"
 
 etcd-set /bootstrap.service/images-control-bootstrapped true
 
-etcd-set /images/chronos      			"index.docker.io/mesosphere/chronos:chronos-2.4.0-0.1.20150828104228.ubuntu1404-mesos-0.27.0-0.2.190.ubuntu1404"
-etcd-set /images/flight-director 		"index.docker.io/behance/flight-director:latest"
-etcd-set /images/marathon     			"index.docker.io/mesosphere/marathon:v0.15.1"
-etcd-set /images/mesos-master 			"index.docker.io/mesosphere/mesos-master:0.27.0-0.2.190.ubuntu1404"
-etcd-set /images/zk-exhibitor 			"index.docker.io/behance/docker-zk-exhibitor:latest"
-etcd-set /images/cfn-signal   			"index.docker.io/behance/docker-cfn-bootstrap:latest"
-etcd-set /images/jenkins				"index.docker.io/jenkins:1.651.1"
-etcd-set /images/dd-agent-mesos 		"index.docker.io/behance/docker-dd-agent-mesos:latest"
+etcd-set /images/chronos                "index.docker.io/mesosphere/chronos:chronos-2.4.0-0.1.20150828104228.ubuntu1404-mesos-0.27.0-0.2.190.ubuntu1404"
+etcd-set /images/flight-director        "index.docker.io/behance/flight-director:latest"
+etcd-set /images/marathon               "index.docker.io/mesosphere/marathon:v0.15.1"
+etcd-set /images/mesos-master           "index.docker.io/mesosphere/mesos-master:0.27.0-0.2.190.ubuntu1404"
+etcd-set /images/zk-exhibitor           "index.docker.io/behance/docker-zk-exhibitor:latest"
+etcd-set /images/cfn-signal             "index.docker.io/behance/docker-cfn-bootstrap:latest"
+etcd-set /images/jenkins                "index.docker.io/jenkins:1.651.1"
+etcd-set /images/dd-agent-mesos         "index.docker.io/behance/docker-dd-agent-mesos:latest"
 etcd-set /images/dd-agent-mesos-master  "index.docker.io/adobeplatform/docker-dd-agent-mesos-master:latest"
 etcd-set /images/dd-agent-mesos-slave   "index.docker.io/adobeplatform/docker-dd-agent-mesos-slave:latest"
-etcd-set /images/dd-agent-proxy			"index.docker.io/behance/docker-dd-agent-proxy:latest"
+etcd-set /images/dd-agent-proxy         "index.docker.io/behance/docker-dd-agent-proxy:latest"
 
 
 etcd-set /bootstrap.service/images-proxy-bootstrapped true
 
-etcd-set /images/capcom       			"index.docker.io/behance/capcom:latest"
-etcd-set /images/capcom2      			"index.docker.io/behance/capcom:latest"
-etcd-set /images/proxy        			"index.docker.io/nginx:1.9.5"
-etcd-set /images/proxy-setup			"index.docker.io/behance/mesos-proxy-setup:latest"
-etcd-set /images/control-proxy   		"index.docker.io/behance/apigateway:v0.0.1"
+etcd-set /images/capcom                 "index.docker.io/behance/capcom:latest"
+etcd-set /images/capcom2                "index.docker.io/behance/capcom:latest"
+etcd-set /images/proxy                  "index.docker.io/nginx:1.9.5"
+etcd-set /images/proxy-setup            "index.docker.io/behance/mesos-proxy-setup:latest"
+etcd-set /images/control-proxy          "index.docker.io/behance/apigateway:v0.0.1"
 
 etcd-set /bootstrap.service/images-worker-bootstrapped true
 
-etcd-set /images/mesos-slave  			"index.docker.io/mesosphere/mesos-slave:0.27.0-0.2.190.ubuntu1404"
+etcd-set /images/mesos-slave            "index.docker.io/mesosphere/mesos-slave:0.27.0-0.2.190.ubuntu1404"
 
 
 ######################
@@ -107,12 +107,12 @@ etcd-set /flight-director/config/authorizer-type airlock
 
 etcd-set /bootstrap.service/zookeeper true
 
-etcd-set /zookeeper/config/exhibitor/s3-prefix 	"zk"
-etcd-set /zookeeper/config/exhibitor/s3-bucket 	$EXHIBITOR_S3BUCKET
-etcd-set /zookeeper/config/ensemble-size 		$CONTROL_CLUSTER_SIZE
-etcd-set /zookeeper/config/endpoint 			$ZOOKEEPER_ENDPOINT
-etcd-set /zookeeper/config/username 			"zk"
-etcd-set /zookeeper/config/password 			"password"
+etcd-set /zookeeper/config/exhibitor/s3-prefix  "zk"
+etcd-set /zookeeper/config/exhibitor/s3-bucket  $EXHIBITOR_S3BUCKET
+etcd-set /zookeeper/config/ensemble-size        $CONTROL_CLUSTER_SIZE
+etcd-set /zookeeper/config/endpoint             $ZOOKEEPER_ENDPOINT
+etcd-set /zookeeper/config/username             "zk"
+etcd-set /zookeeper/config/password             "password"
 
 
 ######################


### PR DESCRIPTION
* Marathon and Chronos require the Zookeeper endpoint to be localhost and not the ELB. This is due to the fact that ELB IPs might change, but Marathon does not re-resolve the new IP using the DNS.