### PR TITLE
Updating etcd-get Function to Check for 4 Response

### DIFF
--- a/v1/lib/helpers.sh
+++ b/v1/lib/helpers.sh
@@ -13,7 +13,8 @@ function etcd-set() {
 
 function etcd-get() {
     etcdctl get "$@"
-    while [ $? != 0 ]; do sleep 1; etcdctl get $@; done
+    # "0" and "4" responses were successful, "4" means the key intentionally doesn't exist
+    while [[ $? != 0 && $? != 4 ]]; do sleep 1; etcdctl get $@; done
 }
 
 # Handle retrying of all fleet submits and starts

--- a/v1/util/jenkins-update-config.sh
+++ b/v1/util/jenkins-update-config.sh
@@ -9,9 +9,12 @@ if [[ ! $1 ]]; then
   exit 1;
 fi
 
-CONTROL_JENKINS_OKTA_METADATA=$(etcdctl get /jenkins/config/okta/metadata)
-CONTROL_JENKINS_ADMIN_GROUP=$(etcdctl get /jenkins/config/okta/admin-group)
-CONTROL_JENKINS_RO_GROUP=$(etcdctl get /jenkins/config/okta/read-group)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $DIR/../lib/helpers.sh
+
+CONTROL_JENKINS_OKTA_METADATA=$(etcd-get /jenkins/config/okta/metadata)
+CONTROL_JENKINS_ADMIN_GROUP=$(etcd-get /jenkins/config/okta/admin-group)
+CONTROL_JENKINS_RO_GROUP=$(etcd-get /jenkins/config/okta/read-group)
 
 if [[ -n $CONTROL_JENKINS_OKTA_METADATA && -n $CONTROL_JENKINS_ADMIN_GROUP && -n $CONTROL_JENKINS_RO_GROUP ]] ; then
   # use the secure Jenkins config


### PR DESCRIPTION
* A "4" exit code from etcd get indicates the value does not exist, but that the etcd call itself was still successful.
* Any other exit code besides 0 and 4 should be treated as a failure of etcd itself (unavailable, etc.) and the repeat should be attempted.
* This PR also adds the use of this function to the jenkins okta util script.