### PR TITLE
made ports match

### DIFF
--- a/v1/fleet/control-proxy.service
+++ b/v1/fleet/control-proxy.service
@@ -19,7 +19,7 @@ ExecStart=/usr/bin/bash -c \
   "/usr/bin/docker run \
   --name control-proxy \
   -e MESOS_MASTER_HOST=http://$($INTERNAL_CONTROL_ELB):5050 \
-  -p 7070:80 \
+  -p 7070:7070 \
   $($IMAGE)"
 ExecStop=/usr/bin/docker stop control-proxy
 


### PR DESCRIPTION
Greetings and thanks for the PR.  We have a few rules so that everyone enjoys your Pull Request.

## Changelog

Changes ports for control-proxy to match inside and outside the container. This is required because the 7070 listener is TCP, not Layer 7 and doesn't add X-Forwarded-For headers required by the gateway to work on different ports.

## Notes

You must explain how any `docker run` executions your PR introduces handles log accumulation. 

Any docker containers introduced through your commit must not accumulate logs in an unsustainable manner.  In other words, no unmanaged logs that aren't/can't be rotated.  

If your PR relies on the default docker log driver, `json`, then this simply means ensuring all `docker run` commands are decorated with either/both of `--log-opt max-size=XX` / `--log-opt max-file=YY` (see the docker documentation for valid XX/YY values)


Did you introduce any command that executes `docker run`?

NO

If you did, have you ensured that all your `docker run` using the default logger have either `max-size` and/or `max-file` set?

NO

Are there any dependencies on github.com/adobe-platform/infrastructure?

NO

If so:
 
Is an update to the base stack required(rare)?

Is an A/B required? YES

Are you dependent on new secrets, or infrastructure in any way? NO




