### PR TITLE
changes to splunk opt units

### DIFF
--- a/v1/opt/splunk/fleet/journald-splunk-pipe.service
+++ b/v1/opt/splunk/fleet/journald-splunk-pipe.service
@@ -5,13 +5,13 @@ Wants=splunk-journald.service
 [Service]
 EnvironmentFile=/etc/environment
 Environment="INSTANCEID=curl -s http://169.254.169.254/latest/meta-data/ami-id"
-Environment="PUBLICHOSTNAME=curl -s http://169.254.169.254/latest/meta-data/public-hostname"
+Environment="HOSTNAME=curl -s http://169.254.169.254/latest/meta-data/hostname"
 TimeoutStartSec=0
 Restart=always
 RestartSec=5s
 ExecStartPre=/usr/bin/systemctl is-active bootstrap
 ExecStartPre=/usr/bin/systemctl is-active splunk-journald
-ExecStart=/bin/sh -c 'journalctl -o json -f | jq --arg instanceid $($INSTANCEID) \'. + {instanceid: $instanceid}\' | jq --arg publichostname $($PUBLICHOSTNAME) \'. + {publichostname: $publichostname}\' | ncat --udp localhost 1514'
+ExecStart=/bin/sh -c 'journalctl -o json -f | jq --arg instanceid $($INSTANCEID) \'. + {instanceid: $instanceid}\' | jq --arg hostname $($HOSTNAME) \'. + {hostname: $hostname}\' | ncat --udp localhost 1514'
 [Install]
 WantedBy=multi-user.target
 [X-Fleet]

--- a/v1/opt/splunk/fleet/journald-splunk-pipe.service
+++ b/v1/opt/splunk/fleet/journald-splunk-pipe.service
@@ -11,7 +11,7 @@ Restart=always
 RestartSec=5s
 ExecStartPre=/usr/bin/systemctl is-active bootstrap
 ExecStartPre=/usr/bin/systemctl is-active splunk-journald
-ExecStart=/bin/sh -c 'journalctl -o json -f | jq --arg instanceid $($INSTANCEID) \'. + {instanceid: $instanceid}\' | jq --arg hostname $($HOSTNAME) \'. + {hostname: $hostname}\' | ncat --udp localhost 1514'
+ExecStart=/bin/sh -c 'journalctl -o json -f | jq --arg instanceid $($INSTANCEID) \'. + {instanceid: $instanceid}\' | jq --arg hostname $($HOSTNAME) \'. + {hostname: $hostname}\' | ncat -v --udp localhost 1514'
 [Install]
 WantedBy=multi-user.target
 [X-Fleet]

--- a/v1/opt/splunk/setup/common/splunk.sh
+++ b/v1/opt/splunk/setup/common/splunk.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash -x
+#!/bin/bash 
 source /etc/environment
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/../../../../lib/helpers.sh 
@@ -13,7 +13,7 @@ cat << EOF > /$SPLUNK_DIR/adobecaas.crt
 $(etcd-get /splunk/config/adobecaas-cert | awk '{gsub(/\\n/,"\n")}1')
 EOF
 
-cat << EOF > /$SPLUNK_DIR./genericForwarder.pem
+cat << EOF > /$SPLUNK_DIR/genericForwarder.pem
 $(etcd-get /splunk/config/ca-cert | awk '{gsub(/\\n/,"\n")}1')
 EOF
 

--- a/v1/opt/splunk/setup/common/splunk.sh
+++ b/v1/opt/splunk/setup/common/splunk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/bash -x
 source /etc/environment
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/../../../../lib/helpers.sh 


### PR DESCRIPTION
Greetings and thanks for the PR.  We have a few rules so that everyone enjoys your Pull Request.

## Changelog

splunk.sh chmod +x 
changes in fleetunit for hostname
changes in setup.sh script.

## Notes

You must explain how any `docker run` executions your PR introduces handles log accumulation. 

Any docker containers introduced through your commit must not accumulate logs in an unsustainable manner.  In other words, no unmanaged logs that aren't/can't be rotated.  

If your PR relies on the default docker log driver, `json`, then this simply means ensuring all `docker run` commands are decorated with either/both of `--log-opt max-size=XX` / `--log-opt max-file=YY` (see the docker documentation for valid XX/YY values)


Did you introduce any command that executes `docker run`? No

If you did, have you ensured that all your `docker run` using the default logger have either `max-size` and/or `max-file` set?

Are there any dependencies on github.com/adobe-platform/infrastructure?

If so:
 
Is an update to the base stack required(rare)? No

Is an A/B required? Yes

Are you dependent on new secrets, or infrastructure in any way? No




