### PR TITLE
Adjusting ecr login script to accomodate multiple registries

### DIFF
--- a/v1/opt/ecr/fleet/aws-ecr-login.service
+++ b/v1/opt/ecr/fleet/aws-ecr-login.service
@@ -14,17 +14,7 @@ ExecStartPre=/usr/bin/sh -c "source /etc/profile.d/etcdctl.sh && docker pull $($
 ExecStartPre=-/usr/bin/docker kill ecr-login
 ExecStartPre=-/usr/bin/docker rm -f ecr-login
 # ecr-login fetches ECR creds and formats them correctly for .dockercfg
-ExecStart=/bin/bash -c \
-    'source /etc/profile.d/etcdctl.sh && \
-    if [[ -n `etcdctl get /ECR/config/registry-account` ]]; then \
-    docker run \
-    --label com.swipely.iam-docker.iam-profile="$CONTAINERS_ROLE" \
-    --name ecr-login \
-    -e "TEMPLATE=templates/dockercfg.tmpl" \
-    -e "AWS_REGION=`etcdctl get /ECR/config/region`" \
-    -e "REGISTRIES=`etcdctl get /ECR/config/registry-account`" \
-    $($IMAGE) >/home/core/.dockercfg; \
-    fi'
+ExecStart=/home/core/ethos-systemd/v1/opt/ecr/util/ecr-login.sh
 ExecStop=/usr/bin/docker stop ecr-login
 
 [X-Fleet]

--- a/v1/opt/ecr/util/ecr-login.sh
+++ b/v1/opt/ecr/util/ecr-login.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/bash -x
+
+source /etc/profile.d/etcdctl.sh
+source /etc/environment
+
+IMAGE=$(etcdctl get /images/ecr-login)
+REGISTRY_ACCOUNT=$(etcdctl get /ECR/config/registry-account)
+AWS_REGION=$(etcdctl get /ECR/config/region)
+DOCKER_CFG_LOCATION="/home/core/.dockercfg"
+
+# Remove old docker container
+docker rm -f ecr-login || :
+
+function copyAndExit() {
+	sudo cp $DOCKER_CFG_LOCATION /root/.dockercfg
+	exit 0
+}
+
+if [[ -n "$REGISTRY_ACCOUNT" ]]; then
+    ECR_CFG=$(docker run --label com.swipely.iam-docker.iam-profile="$CONTAINERS_ROLE" --name ecr-login -e "TEMPLATE=templates/dockercfg.tmpl" -e "AWS_REGION=$AWS_REGION" -e "REGISTRIES=$REGISTRY_ACCOUNT" $IMAGE)
+
+    if [[ -z $ECR_CFG ]]; then
+    	echo "ECR config could not be obtained"
+    	exit 1
+    fi
+
+    ECR_CFG_REGISTRY=$(echo $ECR_CFG | jq 'keys[0]')
+
+    if [[ -z $ECR_CFG_REGISTRY ]]; then
+    	echo "ECR config did not contain valid registry"
+    	exit 1
+    fi
+
+    ECR_CFG_CONTENTS=$(echo $ECR_CFG | jq ".$ECR_CFG_REGISTRY")
+
+    if [[ -z $ECR_CFG_CONTENTS ]]; then
+    	echo "ECR config did not contain valid contents"
+    	exit 1
+    fi
+
+    # If a dockercfg file doesn't already exist (odd), we can just write and exit
+    if [[ ! -f $DOCKER_CFG_LOCATION || ! -s $DOCKER_CFG_LOCATION ]]; then
+    	echo "$ECR_CFG" > $DOCKER_CFG_LOCATION
+    	copyAndExit
+    fi
+
+    # Otherwise, need to append or modify the new config to existing
+    EXISTING_CFG=$(cat $DOCKER_CFG_LOCATION)
+    NEW_CONFIG=$(echo $EXISTING_CFG | jq ".$ECR_CFG_REGISTRY=$ECR_CFG_CONTENTS")
+
+    echo $NEW_CONFIG > $DOCKER_CFG_LOCATION
+
+    copyAndExit
+else
+	echo "No registry account set"
+	exit 0
+fi


### PR DESCRIPTION
## Changelog
* Updated the ECR service to call a util script instead of running `docker run` code directly inline
* New util script uses jq to parse existing .dockercfg file and append or overwrite new ECR login info