### PR TITLE
lock booster version

### DIFF
--- a/v1/setup/leader/001-defaults.sh
+++ b/v1/setup/leader/001-defaults.sh
@@ -27,7 +27,7 @@ etcd-set /images/mesos-master           "index.docker.io/mesosphere/mesos-master
 etcd-set /images/zk-exhibitor           "index.docker.io/behance/docker-zk-exhibitor:latest"
 etcd-set /images/cfn-signal             "index.docker.io/behance/docker-cfn-bootstrap:latest"
 etcd-set /images/jenkins                "index.docker.io/jenkins:1.651.1"
-etcd-set /images/booster                "index.docker.io/behance/booster:erl"
+etcd-set /images/booster                "index.docker.io/behance/booster:0.1"
 
 etcd-set /bootstrap.service/images-proxy-bootstrapped true
 


### PR DESCRIPTION
## Changelog

Version lock booster

## Notes

You must explain how any `docker run` executions your PR introduces handles log accumulation. 

Any docker containers introduced through your commit must not accumulate logs in an unsustainable manner.  In other words, no unmanaged logs that aren't/can't be rotated.  

If your PR relies on the default docker log driver, `json`, then this simply means ensuring all `docker run` commands are decorated with either/both of `--log-opt max-size=XX` / `--log-opt max-file=YY` (see the docker documentation for valid XX/YY values)


Did you introduce any command that executes `docker run`? **No**

If you did, have you ensured that all your `docker run` using the default logger have either `max-size` and/or `max-file` set? **N/A**

Are there any dependencies on github.com/adobe-platform/infrastructure? **No**

If so:
 
Is an update to the base stack required(rare)?

Is an A/B required?

Are you dependent on new secrets, or infrastructure in any way?




