### PR TITLE
FD + aqua + Booster updates

### DIFF
--- a/v1/lib/helpers.sh
+++ b/v1/lib/helpers.sh
@@ -29,3 +29,61 @@ function start-fleet-unit() {
     sudo fleetctl start "$@"
     while [ $? != 0 ]; do sleep 1; sudo fleetctl start $@; done
 }
+
+
+#
+# URI parsing function
+#
+# The function creates global variables with the parsed results.
+# It returns 0 if parsing was successful or non-zero otherwise.
+#
+# [schema://][user[:password]@]host[:port][/path][?[arg1=val1]...][#fragment]
+#
+function uri_parser() {
+    # uri capture
+    uri="$@"
+
+    # safe escaping
+    uri="${uri//\`/%60}"
+    uri="${uri//\"/%22}"
+
+    # top level parsing
+    pattern='^(([a-z]{3,5})://)?((([^:\/]+)(:([^@\/]*))?@)?([^:\/?]+)(:([0-9]+))?)(\/[^?]*)?(\?[^#]*)?(#.*)?$'
+    [[ "$uri" =~ $pattern ]] || return 0;
+
+    # component extraction
+    uri=${BASH_REMATCH[0]}
+    uri_schema=${BASH_REMATCH[2]}
+    uri_address=${BASH_REMATCH[3]}
+    uri_user=${BASH_REMATCH[5]}
+    uri_password=${BASH_REMATCH[7]}
+    uri_host=${BASH_REMATCH[8]}
+    uri_port=${BASH_REMATCH[10]}
+    uri_path=${BASH_REMATCH[11]}
+    uri_query=${BASH_REMATCH[12]}
+    uri_fragment=${BASH_REMATCH[13]}
+
+    # path parsing
+    count=0
+    path="$uri_path"
+    pattern='^/+([^/]+)'
+    while [[ $path =~ $pattern ]]; do
+        eval "uri_parts[$count]=\"${BASH_REMATCH[1]}\""
+        path="${path:${#BASH_REMATCH[0]}}"
+        let count++
+    done
+
+    # query parsing
+    count=0
+    query="$uri_query"
+    pattern='^[?&]+([^= ]+)(=([^&]*))?'
+    while [[ $query =~ $pattern ]]; do
+        eval "uri_args[$count]=\"${BASH_REMATCH[1]}\""
+        eval "uri_arg_${BASH_REMATCH[1]}=\"${BASH_REMATCH[3]}\""
+        query="${query:${#BASH_REMATCH[0]}}"
+        let count++
+    done
+
+    # return success
+    return 0
+}

--- a/v1/setup/leader/001-defaults.sh
+++ b/v1/setup/leader/001-defaults.sh
@@ -17,7 +17,7 @@ etcd-set /images/secrets-downloader     "index.docker.io/behance/docker-aws-secr
 etcd-set /images/klam-ssh               "index.docker.io/behance/klam-ssh:v1"
 
 etcd-set /images/chronos                "index.docker.io/mesosphere/chronos:chronos-2.4.0-0.1.20150828104228.ubuntu1404-mesos-0.27.0-0.2.190.ubuntu1404"
-etcd-set /images/flight-director        "index.docker.io/behance/flight-director:53784a9772ec1bc5e1da2c957ab1ded0e3677b0d"
+etcd-set /images/flight-director        "index.docker.io/behance/flight-director:a3240d5cec9e69e0a892fb2c8945f776ec455b2f"
 etcd-set /images/marathon               "index.docker.io/mesosphere/marathon:v0.15.1"
 etcd-set /images/mesos-master           "index.docker.io/mesosphere/mesos-master:0.27.0-0.2.190.ubuntu1404"
 etcd-set /images/zk-exhibitor           "index.docker.io/behance/docker-zk-exhibitor:v1.0.0"

--- a/v1/setup/leader/001-defaults.sh
+++ b/v1/setup/leader/001-defaults.sh
@@ -82,7 +82,7 @@ etcd-set /flight-director/config/mesos-master-protocol http
 etcd-set /flight-director/config/authorizer-type airlock
 etcd-set /flight-director/config/iam-role-label com.swipely.iam-docker.iam-profile
 etcd-set /flight-director/config/scaler-protocol http
-etcd-set /flight-director/config/scaler-endpoint localhost
+etcd-set /flight-director/config/scaler-endpoint localhost:2042
 
 ######################
 #     ZOOKEEPER

--- a/v1/setup/leader/001-defaults.sh
+++ b/v1/setup/leader/001-defaults.sh
@@ -83,6 +83,7 @@ etcd-set /flight-director/config/authorizer-type airlock
 etcd-set /flight-director/config/iam-role-label com.swipely.iam-docker.iam-profile
 etcd-set /flight-director/config/scaler-protocol http
 etcd-set /flight-director/config/scaler-endpoint localhost:2042
+etcd-set /flight-director/config/aqua-user administrator
 
 ######################
 #     ZOOKEEPER

--- a/v1/setup/leader/001-defaults.sh
+++ b/v1/setup/leader/001-defaults.sh
@@ -17,7 +17,7 @@ etcd-set /images/secrets-downloader     "index.docker.io/behance/docker-aws-secr
 etcd-set /images/klam-ssh               "index.docker.io/behance/klam-ssh:v1"
 
 etcd-set /images/chronos                "index.docker.io/mesosphere/chronos:chronos-2.4.0-0.1.20150828104228.ubuntu1404-mesos-0.27.0-0.2.190.ubuntu1404"
-etcd-set /images/flight-director        "index.docker.io/behance/flight-director:4db22fcd475f200c195a3f5e116f06604e894426"
+etcd-set /images/flight-director        "index.docker.io/behance/flight-director:53784a9772ec1bc5e1da2c957ab1ded0e3677b0d"
 etcd-set /images/marathon               "index.docker.io/mesosphere/marathon:v0.15.1"
 etcd-set /images/mesos-master           "index.docker.io/mesosphere/mesos-master:0.27.0-0.2.190.ubuntu1404"
 etcd-set /images/zk-exhibitor           "index.docker.io/behance/docker-zk-exhibitor:v1.0.0"

--- a/v1/util/flight-director.sh
+++ b/v1/util/flight-director.sh
@@ -9,6 +9,17 @@ then
   SCALER_ENDPOINT=`etcdctl get /flight-director/config/scaler-endpoint`
 fi
 
+#only set Aqua endpoints for FD if Aqua is enabled
+if [[ "$(etcdctl get /environment/services)" == *"aqua"* ]]
+then
+  AQUA_PROTOCOL=`etcdctl get /flight-director/config/aqua-protocol`
+  AQUA_ENDPOINT=`etcdctl get /flight-director/config/aqua-endpoint`
+  AQUA_USER=`etcdctl get /flight-director/config/aqua-user`
+  AQUA_PASSWORD=`etcdctl get /flight-director/config/aqua-password`
+else
+  AQUA_ENDPOINT=""
+fi
+
 
 /usr/bin/docker run \
   --name flight-director \
@@ -42,4 +53,8 @@ fi
   -e FD_ALLOW_MARATHON_UNVERIFIED_TLS=`etcdctl get /flight-director/config/allow-marathon-unverified-tls` \
   -e FD_SCALER_PROTOCOL=`etcdctl get /flight-director/config/scaler-protocol` \
   -e FD_SCALER_ENDPOINT=$SCALER_ENDPOINT \
+  -e FD_AQUA_PROTOCOL=AQUA_PROTOCOL \
+  -e FD_AQUA_ENDPOINT=AQUA_ENDPOINT \
+  -e FD_AQUA_USER=AQUA_USER \
+  -e FD_AQUA_PASSWORD=AQUA_PASSWORD \
   $IMAGE

--- a/v1/util/flight-director.sh
+++ b/v1/util/flight-director.sh
@@ -12,8 +12,11 @@ fi
 #only set Aqua endpoints for FD if Aqua is enabled
 if [[ "$(etcdctl get /environment/services)" == *"aqua"* ]]
 then
-  AQUA_PROTOCOL=`etcdctl get /flight-director/config/aqua-protocol`
-  AQUA_ENDPOINT=`etcdctl get /flight-director/config/aqua-endpoint`
+  AQUA_URL=`etcdctl get /aqua/config/gateway-external`
+  uri_parser($AQUA_URL)
+
+  AQUA_PROTOCOL=$uri_schema
+  AQUA_ENDPOINT=$uri_address
   AQUA_USER=`etcdctl get /flight-director/config/aqua-user`
   AQUA_PASSWORD=`etcdctl get /flight-director/config/aqua-password`
 else

--- a/v1/util/flight-director.sh
+++ b/v1/util/flight-director.sh
@@ -53,8 +53,8 @@ fi
   -e FD_ALLOW_MARATHON_UNVERIFIED_TLS=`etcdctl get /flight-director/config/allow-marathon-unverified-tls` \
   -e FD_SCALER_PROTOCOL=`etcdctl get /flight-director/config/scaler-protocol` \
   -e FD_SCALER_ENDPOINT=$SCALER_ENDPOINT \
-  -e FD_AQUA_PROTOCOL=AQUA_PROTOCOL \
-  -e FD_AQUA_ENDPOINT=AQUA_ENDPOINT \
-  -e FD_AQUA_USER=AQUA_USER \
-  -e FD_AQUA_PASSWORD=AQUA_PASSWORD \
+  -e FD_AQUA_PROTOCOL=$AQUA_PROTOCOL \
+  -e FD_AQUA_ENDPOINT=$AQUA_ENDPOINT \
+  -e FD_AQUA_USER=$AQUA_USER \
+  -e FD_AQUA_PASSWORD=$AQUA_PASSWORD \
   $IMAGE


### PR DESCRIPTION
Greetings and thanks for the PR.  We have a few rules so that everyone enjoys your Pull Request.

## Changelog

- Updates default Booster port for FD
- Sends Aqua vars to FD
- New FD (auto-create database, Aqua integration, bug fixes, `/v2/health/check` endpoint)

## Notes

You must explain how any `docker run` executions your PR introduces handles log accumulation. 

Did you introduce any command that executes `docker run`? - No

Are there any dependencies on github.com/adobe-platform/infrastructure? -No

If so:
 
Is an update to the base stack required(rare)? - No

Is an A/B required? - Yes

Are you dependent on new secrets, or infrastructure in any way? - Yes, needs Aqua endpoint,  username and password to be passed in



