### PR TITLE
Set the required params for DD RDS native DB integration

### DIFF
--- a/v1/opt/datadog/fleet/datadog-proxy.service
+++ b/v1/opt/datadog/fleet/datadog-proxy.service
@@ -26,6 +26,9 @@ sudo -E /usr/bin/docker run --name dd-agent-proxy \
 -e PROXY=`etcdctl get /capcom/config/proxy` \
 -e CAPCOM_HOST=`etcdctl get /capcom/config/host` \
 -e CAPCOM_PORT=`etcdctl get /capcom/config/port` \
+-e RDS_FD_INSTANCE=`etcdctl get /flight-director/config/db-path | awk -F":" '{print $1}'` \
+-e RDS_FD_USERNAME=`etcdctl get /flight-director/config/db-username` \
+-e RDS_FD_PASSWORD=`etcdctl get /environment/RDSPASSWORD` \
 -e STACK_NAME=$STACK_NAME \
 -e DD_TIER=proxy \
 $($IMAGE)"

--- a/v1/opt/datadog/setup/leader/001-images.sh
+++ b/v1/opt/datadog/setup/leader/001-images.sh
@@ -10,4 +10,4 @@ etcd-set /images/dd-agent-mesos-slave   "index.docker.io/adobeplatform/docker-dd
 etcd-set /images/dd-agent-proxy         "index.docker.io/behance/docker-dd-agent-proxy:latest"
 
 # TODO: remove the keys above as they are not needed anymore
-etcd-set /images/ethos-dd-agent         "index.docker.io/adobeplatform/ethos-dd-agent:v1.0.3"
+etcd-set /images/ethos-dd-agent         "index.docker.io/adobeplatform/ethos-dd-agent:v1.0"

--- a/v1/opt/datadog/setup/leader/001-images.sh
+++ b/v1/opt/datadog/setup/leader/001-images.sh
@@ -10,4 +10,4 @@ etcd-set /images/dd-agent-mesos-slave   "index.docker.io/adobeplatform/docker-dd
 etcd-set /images/dd-agent-proxy         "index.docker.io/behance/docker-dd-agent-proxy:latest"
 
 # TODO: remove the keys above as they are not needed anymore
-etcd-set /images/ethos-dd-agent         "index.docker.io/adobeplatform/ethos-dd-agent:v1.0.4"
+etcd-set /images/ethos-dd-agent         "index.docker.io/adobeplatform/ethos-dd-agent:v1.0"

--- a/v1/opt/datadog/setup/leader/001-images.sh
+++ b/v1/opt/datadog/setup/leader/001-images.sh
@@ -10,4 +10,4 @@ etcd-set /images/dd-agent-mesos-slave   "index.docker.io/adobeplatform/docker-dd
 etcd-set /images/dd-agent-proxy         "index.docker.io/behance/docker-dd-agent-proxy:latest"
 
 # TODO: remove the keys above as they are not needed anymore
-etcd-set /images/ethos-dd-agent         "index.docker.io/adobeplatform/ethos-dd-agent:v1.0"
+etcd-set /images/ethos-dd-agent         "index.docker.io/adobeplatform/ethos-dd-agent:v1.0.3"

--- a/v1/opt/datadog/setup/leader/001-images.sh
+++ b/v1/opt/datadog/setup/leader/001-images.sh
@@ -10,4 +10,4 @@ etcd-set /images/dd-agent-mesos-slave   "index.docker.io/adobeplatform/docker-dd
 etcd-set /images/dd-agent-proxy         "index.docker.io/behance/docker-dd-agent-proxy:latest"
 
 # TODO: remove the keys above as they are not needed anymore
-etcd-set /images/ethos-dd-agent         "index.docker.io/adobeplatform/ethos-dd-agent:v1.0"
+etcd-set /images/ethos-dd-agent         "index.docker.io/adobeplatform/ethos-dd-agent:v1.0.4"


### PR DESCRIPTION
Greetings and thanks for the PR.  We have a few rules so that everyone enjoys your Pull Request.

## Changelog
- Add the following params to `datadog-proxy` fleet service: 
`RDS_FD_INSTANCE`,  
`RDS_FD_USERNAME`, 
`RDS_FD_PASSWORD`

## Notes

You must explain how any `docker run` executions your PR introduces handles log accumulation. 

Did you introduce any command that executes `docker run`?
R: No

Are there any dependencies on github.com/adobe-platform/infrastructure?
R: no

If so:
 
Is an update to the base stack required(rare)?
R: N/A

Is an A/B required?
R: Yes

Are you dependent on new secrets, or infrastructure in any way?
R: No


