### PR TITLE
remove aqua health check as it is no longer required

### DIFF
--- a/v1/fleet/worker-booster.service
+++ b/v1/fleet/worker-booster.service
@@ -9,7 +9,6 @@ User=core
 Restart=on-failure
 Environment="IMAGE=etcdctl get /images/booster"
 
-ExecStartPre=/home/core/ethos-systemd/v1/opt/aqua/util/aqua-agent-health.sh
 ExecStartPre=/usr/bin/bash -c "[ -f /home/core/.dockercfg ] || exit 1"
 ExecStartPre=/usr/bin/bash -c "[ -f /opt/mesos/credentials ] || exit 1"
 ExecStartPre=/usr/bin/sh -c ". /etc/profile.d/etcdctl.sh && docker pull $($IMAGE)"


### PR DESCRIPTION
Greetings and thanks for the PR.  We have a few rules so that everyone enjoys your Pull Request.

## Changelog

## Notes

You must explain how any `docker run` executions your PR introduces handles log accumulation. 

Did you introduce any command that executes `docker run`?

Are there any dependencies on github.com/adobe-platform/infrastructure?

If so:
 
Is an update to the base stack required(rare)?

Is an A/B required?

Are you dependent on new secrets, or infrastructure in any way?




